### PR TITLE
Restructured Database

### DIFF
--- a/coredotfinance/data.py
+++ b/coredotfinance/data.py
@@ -195,7 +195,11 @@ class KrxReader:
         pd.DataFrame
             data
         """
-        return self.read(symbol, start='1900-01-01', end='2030-01-01', kind=kind, api=api)
+
+        if api:
+            return krx_db.read_all(symbol, kind=kind, resource='krx', api_key=self.api_key)
+        else:
+            return self.read(symbol, start='1900-01-01', end='2030-01-01', kind=kind, api=api)
 
     def read_date(self, date=None, *, kind='stock', api=False):
         """

--- a/coredotfinance/data.py
+++ b/coredotfinance/data.py
@@ -83,9 +83,9 @@ class KrxReader:
 
         Examples
         --------
-        from coredotfinance.data import KrxReader
-        krx = KrxReader()
-        krx.search('삼성전자')
+        >>> from coredotfinance.data import KrxReader
+        >>> krx = KrxReader()
+        >>> krx.search('삼성전자')
 
         >>> ('삼성전자', 'KR7005930003', '005930')
         """

--- a/coredotfinance/database/krx_db.py
+++ b/coredotfinance/database/krx_db.py
@@ -4,7 +4,7 @@ import requests
 import pandas as pd
 import numpy as np
 
-__url = 'http://52.79.172.205:8080/'
+__url = 'http://15.165.18.200:8080/'
 
 def _requests_with_retry(url):
     for _ in range(5):
@@ -13,7 +13,7 @@ def _requests_with_retry(url):
             response = requests.get(url, timeout = 15).json()
         except requests.exceptions.ReadTimeout:
             retry = True
-            response = {'msg' : 'Error : requests.exceptions.ReadTimeout'}
+            response = {'msg': 'Error : requests.exceptions.ReadTimeout'}
         if retry:
             continue
         else:
@@ -21,7 +21,20 @@ def _requests_with_retry(url):
     return response
 
 
-def read(symbol, start, end, kind, resource, api_key, **kwargs):
+def read(symbol, start, end, kind, resource, api_key):
+
+    url = os.path.join(__url, resource, kind, 'read', f'?symbol={symbol}&start={start}&end={end}&apikey={api_key}')
+    response = _requests_with_retry(url)
+    if response.get('msg', False):
+        return response
+
+    data = response['data']
+    df = pd.DataFrame(data)
+
+    return df
+
+
+def read_all(symbol, kind, resource, api_key):
     """
     api를 사용해서 해당 종목의 데이터를 받는
 
@@ -30,17 +43,8 @@ def read(symbol, start, end, kind, resource, api_key, **kwargs):
     symbol : str
         조회하고자 하는 데이터의 종목코드.
         형태는 종목과 종류마다 다르다. 예) 삼성전자 : '005930', ARIRANG 200 : '152100'
-    start : str
-        조회하고자 하는 데이터의 시작일.
-        형태는 YYYY-MM-DD가 되어야 한다. 예) 2021-06-01
-    end : str
-        조회하고자 하는 데이터의 종료일.
-        형태는 YYYY-MM-DD가 되어야 한다. 예) 2021-06-01
     kind : str, default "stock"
         조회하고자 하는 데이터의 종류.
-    api : bool, default False
-        api_key가 설정되어 있지 않으면서 api가 True면 error가 발생한다.
-        api 이용은 주식 가격만 가능하다.
     resource : str
         url 주소를 완성하기 위한 것으로 데이터의 출처값을 있다.
     api_key : str
@@ -51,20 +55,16 @@ def read(symbol, start, end, kind, resource, api_key, **kwargs):
     pd.DataFrame
 
     """
-    whole = kwargs.get('whole', False)
-    url = os.path.join(__url, resource, kind, 'read', f'?symbol={symbol}&apikey={api_key}')
+    url = os.path.join(__url, resource, kind, 'read-all', f'?symbol={symbol}&apikey={api_key}')
     response = _requests_with_retry(url)
     if response.get('msg', False):
         return response
 
     data = response['data']
     df = pd.DataFrame(data)
-    df.index = df['날짜']
+    df.index = df['date']
     df.index.name = ''
-    transformed = df.drop(['종목명', '시장구분', '소속부', '날짜'], axis='columns')
-
-    if not whole:
-        transformed = transformed[np.logical_and(transformed.index >= start, transformed.index <= end)]
+    transformed = df.drop(['name', 'market', 'division', 'date'], axis='columns')
 
     return transformed
 
@@ -91,18 +91,9 @@ def read_date(date, kind, resource, api_key):
 
     """
 
-    url = os.path.join(__url, resource, kind, 'readall', f'?date={date}&apikey={api_key}')
+    url = os.path.join(__url, resource, kind, 'read-date', f'?date={date}&apikey={api_key}')
     response = _requests_with_retry(url)
     if response.get('msg', False):
         return response
-
     data = response['data']
-    data_list = []
-    length = len(data['종목코드'])
-    for i in range(length):
-        data_dict = {}
-        for key in data:
-            data_dict[key] = data[key][str(i)]
-        data_list.append(data_dict)
-
-    return pd.DataFrame(data_list)
+    return pd.DataFrame(data)

--- a/coredotfinance/database/krx_db.py
+++ b/coredotfinance/database/krx_db.py
@@ -2,15 +2,15 @@ import os
 import requests
 
 import pandas as pd
-import numpy as np
 
 __url = 'http://15.165.18.200:8080/'
+
 
 def _requests_with_retry(url):
     for _ in range(5):
         try:
             retry = False
-            response = requests.get(url, timeout = 15).json()
+            response = requests.get(url, timeout=15).json()
         except requests.exceptions.ReadTimeout:
             retry = True
             response = {'msg': 'Error : requests.exceptions.ReadTimeout'}
@@ -22,6 +22,30 @@ def _requests_with_retry(url):
 
 
 def read(symbol, start, end, kind, resource, api_key):
+    """
+
+    Parameters
+    ----------
+    symbol : str
+        조회하고자 하는 데이터의 종목코드.
+        형태는 종목과 종류마다 다르다. 예) 삼성전자 : '005930', ARIRANG 200 : '152100'
+    kind : str, default "stock"
+        조회하고자 하는 데이터의 종류.
+    resource : str
+        url 주소를 완성하기 위한 것으로 데이터의 출처값을 있다.
+    api_key : str
+        api key
+    start : str
+        조회하고자 하는 데이터의 시작일.
+        형태는 YYYY-MM-DD가 되어야 한다. 예) 2021-06-01
+    end : str
+        조회하고자 하는 데이터의 종료일.
+        형태는 YYYY-MM-DD가 되어야 한다. 예) 2021-06-01
+
+    Returns
+    -------
+    pd.DataFrame
+    """
 
     url = os.path.join(__url, resource, kind, 'read', f'?symbol={symbol}&start={start}&end={end}&apikey={api_key}')
     response = _requests_with_retry(url)


### PR DESCRIPTION
기존에는 Mongodb의 하나의 collection에서 전체 데이터와 기간별 데이터를 가져왔다. 이때 문제는 기간별 데이터 (예 2021-07-01 ~ 2021-07-10)를 받아올때 총 기간 데이터(상장일~ 현재일)를 받아오고 나서 후처리를 통해 기간별 데이터로 만들어 주었다. MongoDB와 FastAPI server에 부담이 되므로 MongoDB Collection을 추가했다. 하나는 개별 데이터를 개별 문서로 저장하는 collection이고 하나는 전기간 데이터를 하나의 개별 문서로 저장하는 collection이다. `read_all` 을 할때는 전체 데이터 collection에 접근하고, `read` 를 할 때는 기간변 데이터 collection에 접근한다.  