### PR TITLE
Fix : Error about value with wrong tag string

### DIFF
--- a/coredotfinance/data.py
+++ b/coredotfinance/data.py
@@ -370,8 +370,6 @@ class KrxReader:
             dataframe = data_reader("11001", date=date_8_digit, kind=kind, **kwargs)
         elif kind == "other_index":
             dataframe = data_reader("11010", date=date_8_digit, kind=kind, **kwargs)
-        else:
-            raise ValueError(f"Check {kind} is not in the list of expected_kind")
 
         if kwargs.get("adjust", None) is True:
             warnings.warn("data from read_date can not be adjusted")

--- a/coredotfinance/data.py
+++ b/coredotfinance/data.py
@@ -243,9 +243,6 @@ class KrxReader:
                 **kwargs,
             )
 
-        else:
-            raise ValueError(f"Check {kind} is not in the list of expected_kind")
-
         return option.options(dataframe=dataframe, **kwargs)
 
     def read_all(self, symbol, *, kind="stock", api=False, **kwargs):

--- a/coredotfinance/data.py
+++ b/coredotfinance/data.py
@@ -358,7 +358,7 @@ class KrxReader:
         elif kind == "per":
             df = data_reader("12021", search_type="전종목", market="전체", date=date_8_digit)
             # 12021 기능 호출시 종목명 <em class ="up"></em> 가 붙어서 나오는 문제를 해결하기 위함
-            df.replace(' <em class ="up"></em>', "", regex=True, inplace=True)
+            df.replace(' <em class ="up">.*</em>', "", regex=True, inplace=True)
             dataframe = df
         elif kind == "etf":
             dataframe = data_reader("13101", date=date_8_digit, kind=kind)


### PR DESCRIPTION
# Error

```python
from coredotfinance.data import KrxReader
krx = KrxReader()
data = krx.read_date('2000-01-01', kind='per')
print(data['name'].head())
```
```
0    CJ39쇼핑 <em class ="up">(락)</em>
1                              KEP전자
2                                KNC
3                               LG가스
4                               LG건설
Name: name, dtype: object
```
- 태그가 같이 리턴되는 에러는 예전에 이미 발견되어서 `df.replace("<em class ="up"></em>", "", regex=True, inplace=True)`를 이용해서 이미 수정코드를 추가해주었다. 
- 하지만 이번에 발견된 에러는 기존 수정코드의 정규분표표현식으로 지울 수 없어 발견되었다.

# Fix
before
```python
df.replace(' <em class ="up"></em>', '', regex=True, inplace=True)
```
after
```python
df.replace(' <em class ="up">.*</em>', '', regex=True, inplace=True)
```