### PR TITLE
Fix : Error about trading-pending item

### DIFF
--- a/coredotfinance/krx/core/option.py
+++ b/coredotfinance/krx/core/option.py
@@ -51,21 +51,12 @@ def adjust_price(dataframe: pd.DataFrame):
 
     for column in available_column_list:
         data = dataframe.get(column)
-        print("\n", "-" * 100, "\n")
-        print("standard_ratio : ", standard_ratio)
-        print("type(standard_ratio) : ", type(standard_ratio))
-        print("\n")
-        print("data : ", data)
-        print("type(data) : ", type(data))
         if data is None:
             continue
         if column == volume:
             # volume only needs to be multiplied by standard_ratio
             dataframe[column] = (data * standard_ratio).astype(int)
         else:
-            print(data)
-            print("data[0] : ", data[0])
-            print("type(data[0]) : ", type(data[0]))
             dataframe[column] = (data / standard_ratio).astype(int)
     return dataframe
 


### PR DESCRIPTION
# Issue
- 거래 정지 종목에 adjust를 적용했을때 `TypeError: unsupported operand type(s) for /: 'str' and 'float'` 발생

# Cause
- data.krx에서 거래 정지 종목의 시가,종가,고가,저가 등의 정보를 `str` 으로 전달

# Changed
- adjust 직전에 `dataframe.replace("0", 0 , inplace=True)` 적용

# Test
- 1 failed, 33 passed
- 1 failed : ETF 종목 Test 